### PR TITLE
Toggling is fine, but for testing, you need absolutes.

### DIFF
--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -5,6 +5,10 @@ include StateInspector::Observers
 class A
   #A.instance_variable_set(:@informant, true) # Set here and not in Minitest's setup or else inconsistent behavior!
   attr_writer :thing
+
+  def self.reset_informant
+    @informant = false
+  end
 end
 class B; attr_accessor :thing end
 class C; attr_accessor :thing end
@@ -13,11 +17,12 @@ class ReporterTest < Minitest::Test
   def observer; StateInspector::Reporter[A] end
   def setup
     StateInspector::Reporter[A] = InternalObserver
-    A.toggle_informant # Don't use here, this results in flaky behavior.
   end
   def teardown; observer.purge end
 
   def test_reports_get_made_from_setter_methods
+    A.toggle_informant # turn on
+
     a = A.new
     a.thing = 4
     assert_equal [[a, "@thing", nil, 4]], observer.values
@@ -34,6 +39,8 @@ class ReporterTest < Minitest::Test
         [a, "@thing", 5, nil]
       ],
       observer.values
+  ensure
+    A.reset_informant
   end
 
   def test_null_observer_for_no_obervers


### PR DESCRIPTION
This adds A.reset_informant for testing (only). It is used in an
ensure on test_reports_get_made_from_setter_methods to clean up after
itself. You could also use it in teardown, but meh.

This also only turns on the informant in the one test that actually
uses it (i.e., the one test that failed when I removed the toggle from
setup).